### PR TITLE
fix: typing of collection options

### DIFF
--- a/src/ArangoMigrate.ts
+++ b/src/ArangoMigrate.ts
@@ -12,7 +12,7 @@ type Collection = DocumentCollection<any> & EdgeCollection<any>
 export interface CollectionOptions {
   collectionName: string
   options?: CreateCollectionOptions & {
-    type?: CollectionType.DOCUMENT_COLLECTION;
+    type?: CollectionType
   }
 }
 
@@ -282,7 +282,12 @@ export class ArangoMigrate {
       let collection
       try {
         if (this.options.autoCreateNewCollections !== false) {
-          collection = await this.db.createCollection(data.collectionName, data.options)
+          /**
+           * NOTE: arangojs *.d.ts invites user to pass "literal" options object
+           * to infer typeof collection. Thus there is no another way to support
+           * collections() API but using this ugly "as any" cast
+           */
+          collection = await this.db.createCollection(data.collectionName, data.options as any)
           createdCollectionCount++
           newCollections.add(collection)
         }


### PR DESCRIPTION
![image](https://github.com/TimMikeladze/arango-migrate/assets/38350304/b6ed72f7-c25c-4dd1-84ae-423bcbbe4513)

Documentation says that I can pass `CollectionType.EDGE_COLLECTION` as collection options.  But in fact i can't, which seems to be a bug.

The solution is a little bit dirty because of very unfriendly typings of `arangojs`. But it just works.