### PR TITLE
Don't error out on missing versions when running down migrations

### DIFF
--- a/__tests__/ArangoMigrate.test.ts
+++ b/__tests__/ArangoMigrate.test.ts
@@ -47,6 +47,29 @@ describe('initialize', () => {
   })
 })
 
+describe('migrationExists', () => {
+  let tu: TestUtil
+
+  beforeAll(async () => {
+    tu = await createTestUtil()
+    await tu.context.am.initialize()
+  })
+
+  afterAll(async () => {
+    await tu.destroy()
+  })
+
+  it('returns true if version exists', async () => {
+    expect(tu.context.am.migrationExists(1)).toBeTruthy();
+  })
+
+  it('returns false if version does not exist ', async () => {
+    tu.context.am = new ArangoMigrate(defaultConfig)
+    await tu.context.am.initialize()
+    expect(tu.context.am.migrationExists(99)).toBeFalsy();
+  })
+})
+
 describe('getMigrationPathFromVersion', () => {
   let tu: TestUtil
 

--- a/__tests__/migrations_with_gap_in_versions/1_initial.js
+++ b/__tests__/migrations_with_gap_in_versions/1_initial.js
@@ -1,0 +1,20 @@
+const migration = {
+  description: 'The first migration',
+  async collections () {
+    return ['todo']
+  },
+  async up (db, step) {
+    await step(() => db.collection('todo').save({
+      _key: '1',
+      title: 'Buy milk',
+      completed: false
+    }))
+  },
+  async down (db, step) {
+    await step(() => db.collection('todo').remove({
+      _key: '1'
+    }))
+  }
+}
+
+export default migration

--- a/__tests__/migrations_with_gap_in_versions/3_add_collection.js
+++ b/__tests__/migrations_with_gap_in_versions/3_add_collection.js
@@ -1,0 +1,32 @@
+import { CollectionType } from 'arangojs/collection'
+
+const migration = {
+  async collections () {
+    return [
+      'user',
+      {
+        collectionName: 'user_todo_edge',
+        options: {
+          type: CollectionType.EDGE_COLLECTION
+        }
+      }
+    ]
+  },
+  async up (db, step) {
+    await step(() => db.collection('user').save({
+      _key: '1',
+      name: 'John Doe'
+    }))
+
+    await step(() => db.collection('user_todo_edge').save({
+      _key: '1',
+      _from: 'user/1',
+      _to: 'todo/1'
+    }))
+  },
+  async afterDown (db, step, data) {
+    await db.collection('user_todo_edge').drop()
+    await db.collection('user').drop()
+  }
+}
+export default migration

--- a/src/ArangoMigrate.ts
+++ b/src/ArangoMigrate.ts
@@ -203,6 +203,10 @@ export class ArangoMigrate {
     }
   }
 
+  public migrationExists (version: number): boolean {
+    return this.getMigrationPathFromVersion(version) !== undefined
+  }
+
   public getMigrationPathFromVersion (version: number): string {
     return this.migrationPaths.find(x => {
       const basename = path.basename(x)

--- a/src/ArangoMigrate.ts
+++ b/src/ArangoMigrate.ts
@@ -412,7 +412,7 @@ export class ArangoMigrate {
     return { appliedMigrations, createdCollections }
   }
 
-  public async runDownMigrations (to?: number, dryRun?: boolean, noHistory?: boolean): Promise<{ appliedMigrations: number, createdCollections: number; }> {
+  public async runDownMigrations (to?: number, dryRun?: boolean, noHistory?: boolean, disallowMissingVersions?: boolean): Promise<{ appliedMigrations: number, createdCollections: number; }> {
     const latestMigration = await this.getLatestMigration()
 
     if (!latestMigration) {
@@ -428,7 +428,7 @@ export class ArangoMigrate {
 
     let version = latestMigration.version
     while (version >= to) {
-      if (!this.migrationExists(version)) {
+      if (!this.migrationExists(version) && !disallowMissingVersions) {
         version--
         continue
       }

--- a/src/ArangoMigrate.ts
+++ b/src/ArangoMigrate.ts
@@ -426,16 +426,16 @@ export class ArangoMigrate {
     let appliedMigrations = 0
     let createdCollections = 0
 
-    for (let i = latestMigration.version; i >= to; i--) {
+    for (let version = latestMigration.version; version >= to; version--) {
       let migration: Migration
       try {
-        migration = await this.getMigrationFromVersion(i)
+        migration = await this.getMigrationFromVersion(version)
       } catch (err) {
         console.log(err)
         return
       }
 
-      const name = path.basename(this.getMigrationPathFromVersion(i))
+      const name = path.basename(this.getMigrationPathFromVersion(version))
 
       const collectionNames = migration.collections ? await migration.collections() : []
 
@@ -460,7 +460,7 @@ export class ArangoMigrate {
           downResult = await migration.down(this.db, (callback: () => Promise<any>) => transaction.step(callback), beforeDownData)
         } catch (err) {
           console.log(err)
-          error = new Error(`Running up failed for migration ${i}.`)
+          error = new Error(`Running up failed for migration ${version}.`)
         }
       }
 
@@ -492,7 +492,7 @@ export class ArangoMigrate {
 
       if (!error) {
         if (!dryRun && noHistory !== true) {
-          await this.writeMigrationHistory('down', name, migration.description, i)
+          await this.writeMigrationHistory('down', name, migration.description, version)
         }
       }
 

--- a/src/ArangoMigrate.ts
+++ b/src/ArangoMigrate.ts
@@ -428,6 +428,11 @@ export class ArangoMigrate {
 
     let version = latestMigration.version
     while (version >= to) {
+      if (!this.migrationExists(version)) {
+        version--
+        continue
+      }
+
       let migration: Migration
       try {
         migration = await this.getMigrationFromVersion(version)

--- a/src/ArangoMigrate.ts
+++ b/src/ArangoMigrate.ts
@@ -426,7 +426,8 @@ export class ArangoMigrate {
     let appliedMigrations = 0
     let createdCollections = 0
 
-    for (let version = latestMigration.version; version >= to; version--) {
+    let version = latestMigration.version
+    while (version >= to) {
       let migration: Migration
       try {
         migration = await this.getMigrationFromVersion(version)
@@ -500,6 +501,7 @@ export class ArangoMigrate {
         throw error
       }
       appliedMigrations += 1
+      version--
     }
     return { appliedMigrations, createdCollections }
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,8 @@ import { ArangoMigrate, DEFAULT_CONFIG_PATH } from './ArangoMigrate'
 
 interface CommanderOptions {
     config?: string,
-    down?: boolean
+    disallowMissingVersions?: boolean,
+    down?: boolean,
     dryRun?: boolean,
     init?: string,
     list?: boolean,
@@ -29,6 +30,7 @@ interface CommanderOptions {
     .option('-l --list', 'list all applied migrations')
     .option('-dr --dry-run', 'dry run. Executes migration lifecycle functions but never commits the transaction to the database or writes to the migration history log')
     .option('-nh --no-history', 'Skips writing to the migration history log. Use this with caution since the applied migrations will not be saved in the migration history log, opening the possibility of applying the same migration multiple times and potentially dirtying your data')
+    .option('--disallow-missing-versions', 'raise an exception if there are missing versions when running down migrations')
 
   program.parse(process.argv)
 
@@ -79,7 +81,7 @@ interface CommanderOptions {
 
       const to = Number(options.to)
 
-      const { createdCollections, appliedMigrations } = await am.runDownMigrations(to, options.dryRun, options.noHistory)
+      const { createdCollections, appliedMigrations } = await am.runDownMigrations(to, options.dryRun, options.noHistory, options.disallowMissingVersions)
       console.log(`${createdCollections} collections created.`)
       if (options.dryRun) {
         console.log(`${appliedMigrations} \`down\` migrations dry ran.`)


### PR DESCRIPTION
Addresses issue #113 by changing the default behavior for running down migrations. Previously, the default behavior was to raise an exception when running down migrations where the versions aren't consecutively numbered (e.g. 1, 2, 5, 9). After this set of changes, the default behavior will be to quietly skip over those gaps and continue running the down migrations until it hits the lower version limit defined by the `to` argument.

One can override this behavior and still get errors by passing the `--disallow-missing-versions` flag on the `arango-migrate` command line.